### PR TITLE
매퍼 대소문자 변경

### DIFF
--- a/src/main/resources/mybatis-mapper/member/MemberMapper.xml
+++ b/src/main/resources/mybatis-mapper/member/MemberMapper.xml
@@ -31,18 +31,18 @@
     <select id="selectMember_byIDPwd" parameterType="String" resultMap="memberListResult">
         <!-- SELECT member.member_no, email, nickname -->
         SELECT *
-        FROM member
+        FROM Member
         WHERE email=#{email} AND password=#{password}
     </select>
 
 	<select id="test" parameterType="int" resultMap="memberListResult">
         SELECT member_no, email
-        FROM member
+        FROM Member
         WHERE member_no = 1
     </select>
     
     <update id = "updateLastDdate" parameterType = "int">
-	    UPDATE member 
+	    UPDATE Member 
 	    SET lastdate = CURRENT_TIMESTAMP 
 	    WHERE member_no = #{no}
     </update>


### PR DESCRIPTION
네이버 클라우드에 올라간 mysql은 리눅스 서버여서 대소문자 지켜줘야함